### PR TITLE
fix typo in string manipulation solution example

### DIFF
--- a/Spring-2019/string_manipulation/SOLUTIONS_2019Spring.md
+++ b/Spring-2019/string_manipulation/SOLUTIONS_2019Spring.md
@@ -51,7 +51,7 @@ Output: `Negative Thirty Four Thousand Six Hundred Eighty Two`
 C++:
 
 ```c++
-#import <string>
+#include <string>
 using namespace std;
 
 string englishInteger(int num);


### PR DESCRIPTION
Tbf, this was inevitable when using C/C++ and Java at the same time.

Fixes #7 