### PR TITLE
One more test case for URLify

### DIFF
--- a/Spring-2019/string_manipulation/SOLUTIONS_2019Spring.md
+++ b/Spring-2019/string_manipulation/SOLUTIONS_2019Spring.md
@@ -119,6 +119,8 @@ $ ./test
 'hi%20there'
 'can I get a heal        '
 'can%20I%20get%20a%20heal'
+' oh oops    '
+'%20oh%20oops'
 $
 ```
 

--- a/Spring-2019/string_manipulation/urlify/urlify.cpp
+++ b/Spring-2019/string_manipulation/urlify/urlify.cpp
@@ -59,7 +59,12 @@ int main() {
     printArray(test2, 24);
     test2 = urlify(test2, 16);
     printArray(test2, 24);
+    char* test3 = new char[12]{' ', 'o', 'h', ' ', 'o', 'o', 'p', 's', ' ', ' ', ' ', ' '};
+    printArray(test3, 12);
+    test3 = urlify(test3, 8);
+    printArray(test3, 12);
     delete test1;
     delete test2;
+    delete test3;
     return 0;
 }


### PR DESCRIPTION
An attendee (Kevin) brought up a potential error in indexing practices for the 2nd pass, but the indexing practice is only relevant to the final array index, not the original index. So, if `for (int i = newLength - 1; i > 0; i--)` reflects the new string, the character comparison of the original string is not affected by `i > 0`.
Consider two cases:
1.	`str[0] == ' '`
	Here, the `i` value will be `2`, but the value of `oldIdx` will be `0`, so the space is treated appropriately and `i`, `i-1`, and `i-2` replacements are performed correctly.
2. 	`str[0] != ' '`
	No replacement is required. Furthermore, due to the equality comparison of `i` and `oldIdx` at the bottom of the for loop, that segment of the string is not modified or compared.